### PR TITLE
Update design token transformer to create a PR instead of committing straight away

### DIFF
--- a/.github/workflows/transform-tokens.yml
+++ b/.github/workflows/transform-tokens.yml
@@ -39,9 +39,13 @@ jobs:
       # We now run npm i to install all dependencies and run the "transfrom" script that is defined in the package.json (change this if you need to)
       - name: Transform design tokens 
         run: 'npm i && npm run transform-tokens'
-      # We now store the changes in the repository
-      - name: Persist changes in repository
-        uses: mikeal/publish-to-github-action@master
+      # We now create a pull request 
+      - name: Create PR 
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "Update tokens"
+          title: "Design token updates"
+          body: "Design tokens have been updated in Figma and need reviewed."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # this parameter is optional and defaults to master but I am using main


### PR DESCRIPTION
As requested in https://github.com/lukasoppermann/design-tokens/issues/80. All it takes is swapping from `mikeal/publish-to-github-action` to `peter-evans/create-pull-request`. I set some default settings for that plugin but feel free to change. 