### PR TITLE
Figma File upload workflow: use filename from Figma plugin settings

### DIFF
--- a/.github/workflows/transform-tokens.yml
+++ b/.github/workflows/transform-tokens.yml
@@ -25,7 +25,7 @@ jobs:
         uses: jsdaniell/create-json@1.1.2
         with:
           # it uses the name from your settings that was send as then tokenFileName parameter
-          name: 'design-tokens-example.json'
+          name: ${{ github.event.client_payload.filename }}
           # it uses the json string that was send as the tokens parameter
           json: ${{ github.event.client_payload.tokens }}
           # it uses the directory named "tokens" to store this json file (change this if you changed it above to use a different folder)


### PR DESCRIPTION
Currently, the workflow action transform-tokens does not respect the user's plugin settings for the file name when exporting the tokens from Figma. The hardcoded value `design-tokens-example.tokens.json` is always used.

This PR uses the `filename` parameter from the client_payload to construct the json file with the file name entered in the user's plugin settings.

The `filename` parameter is already available in the workflow event payload, so there is no accompanying PR in https://github.com/lukasoppermann/design-tokens:  
![design-tokens-upload](https://user-images.githubusercontent.com/28848741/179241851-cc51beef-aa96-43dd-962d-4605cfd6470e.PNG)
