### PR TITLE
fix transformGroup['scss'] reference

### DIFF
--- a/transformTokens.js
+++ b/transformTokens.js
@@ -41,7 +41,7 @@ StyleDictionary.registerTransformGroup({
 
 StyleDictionary.registerTransformGroup({
   name: 'custom/scss',
-  transforms: StyleDictionary.transformGroup['less'].concat([
+  transforms: StyleDictionary.transformGroup['scss'].concat([
     'size/px',
     'size/percent'
   ])


### PR DESCRIPTION
Hi, I found some issues via scss things so I tweaked it.

# issue
If you have hex8 color in tokens.json then you'll get hex6 output in scss. i.e., you'll lose alpha data.
`#000000ff` -> `#000000`

# cause
transformTokens.js
```
StyleDictionary.registerTransformGroup({
  name: 'custom/scss',
  transforms: StyleDictionary.transformGroup['less'].concat([
```
fix:
```
  transforms: StyleDictionary.transformGroup['scss'].concat([
```

maybe `less` things has issues about these things but I didn't dive into there...