### PR TITLE
Fix 'custom-fontStyle' token to return sizes in px

### DIFF
--- a/build/css/_variables.css
+++ b/build/css/_variables.css
@@ -34,12 +34,12 @@
   --color-colors-empty: rgba(0, 0, 0, 0);
   --color-colors-special-characters: rgb(64, 223, 80);
   --color-colors-special-characters-nderung: rgb(52, 86, 175);
-  --font-body-h3: condensed  700 20/32 Akzidenz-Grotesk Pro;
-  --font-body-h4-strike-through: italic 500 16/19.2 Roboto;
-  --font-body-italic: italic 400 12/14 Roboto;
-  --font-body-extra-bold-condensed-italic: condensed italic 800 12/14.4 Akzidenz-Grotesk Pro;
-  --font-body-medium-extended-italic: expanded italic 500 20/24 Akzidenz-Grotesk Pro;
-  --font-body-super: 900 22/26.4 Akzidenz-Grotesk Pro;
+  --font-body-h3: condensed  700 20px/32px Akzidenz-Grotesk Pro;
+  --font-body-h4-strike-through: italic 500 16px/19.2px Roboto;
+  --font-body-italic: italic 400 12px/14px Roboto;
+  --font-body-extra-bold-condensed-italic: condensed italic 800 12px/14.4px Akzidenz-Grotesk Pro;
+  --font-body-medium-extended-italic: expanded italic 500 20px/24px Akzidenz-Grotesk Pro;
+  --font-body-super: 900 22px/26.4px Akzidenz-Grotesk Pro;
   --effect-drop-shadow-single: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   --effect-inner-shadow-multiple-0: inset 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
   --effect-inner-shadow-multiple-1: inset 10px 100px 1px 0.5px rgb(0, 0, 0);

--- a/build/ios-swift/StyleDictionaryColor.swift
+++ b/build/ios-swift/StyleDictionaryColor.swift
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 
 import UIKit

--- a/build/ios-swift/StyleDictionarySize.swift
+++ b/build/ios-swift/StyleDictionarySize.swift
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 
 import UIKit

--- a/build/ios/StyleDictionaryColor.h
+++ b/build/ios/StyleDictionaryColor.h
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 
 #import <UIKit/UIKit.h>

--- a/build/ios/StyleDictionaryColor.m
+++ b/build/ios/StyleDictionaryColor.m
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 
 #import "StyleDictionaryColor.h"

--- a/build/ios/StyleDictionarySize.h
+++ b/build/ios/StyleDictionarySize.h
@@ -3,7 +3,7 @@
 //
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 
 #import <Foundation/Foundation.h>

--- a/build/ios/StyleDictionarySize.m
+++ b/build/ios/StyleDictionarySize.m
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 
 #import "StyleDictionarySize.h"

--- a/build/less/_variables.less
+++ b/build/less/_variables.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 @sizes-32: 32.72px;
 @sizes-40: 40px;
@@ -37,12 +37,12 @@
 @color-colors-empty: rgba(0, 0, 0, 0);
 @color-colors-special-characters: rgb(64, 223, 80);
 @color-colors-special-characters-nderung: rgb(52, 86, 175);
-@font-body-h3: condensed  700 20/32 Akzidenz-Grotesk Pro;
-@font-body-h4-strike-through: italic 500 16/19.2 Roboto;
-@font-body-italic: italic 400 12/14 Roboto;
-@font-body-extra-bold-condensed-italic: condensed italic 800 12/14.4 Akzidenz-Grotesk Pro;
-@font-body-medium-extended-italic: expanded italic 500 20/24 Akzidenz-Grotesk Pro;
-@font-body-super: 900 22/26.4 Akzidenz-Grotesk Pro;
+@font-body-h3: condensed  700 20px/32px Akzidenz-Grotesk Pro;
+@font-body-h4-strike-through: italic 500 16px/19.2px Roboto;
+@font-body-italic: italic 400 12px/14px Roboto;
+@font-body-extra-bold-condensed-italic: condensed italic 800 12px/14.4px Akzidenz-Grotesk Pro;
+@font-body-medium-extended-italic: expanded italic 500 20px/24px Akzidenz-Grotesk Pro;
+@font-body-super: 900 22px/26.4px Akzidenz-Grotesk Pro;
 @effect-drop-shadow-single: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 @effect-inner-shadow-multiple-0: inset 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 @effect-inner-shadow-multiple-1: inset 10px 100px 1px 0.5px rgb(0, 0, 0);

--- a/build/scss/_variables.scss
+++ b/build/scss/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 08 May 2023 07:37:37 GMT
+// Generated on Thu, 16 May 2024 20:48:48 GMT
 
 $sizes-32: 32.72px;
 $sizes-40: 40px;
@@ -37,12 +37,12 @@ $color-colors-ref-blue: rgb(4, 74, 255);
 $color-colors-empty: rgba(0, 0, 0, 0);
 $color-colors-special-characters: rgb(64, 223, 80);
 $color-colors-special-characters-nderung: rgb(52, 86, 175);
-$font-body-h3: condensed  700 20/32 Akzidenz-Grotesk Pro;
-$font-body-h4-strike-through: italic 500 16/19.2 Roboto;
-$font-body-italic: italic 400 12/14 Roboto;
-$font-body-extra-bold-condensed-italic: condensed italic 800 12/14.4 Akzidenz-Grotesk Pro;
-$font-body-medium-extended-italic: expanded italic 500 20/24 Akzidenz-Grotesk Pro;
-$font-body-super: 900 22/26.4 Akzidenz-Grotesk Pro;
+$font-body-h3: condensed  700 20px/32px Akzidenz-Grotesk Pro;
+$font-body-h4-strike-through: italic 500 16px/19.2px Roboto;
+$font-body-italic: italic 400 12px/14px Roboto;
+$font-body-extra-bold-condensed-italic: condensed italic 800 12px/14.4px Akzidenz-Grotesk Pro;
+$font-body-medium-extended-italic: expanded italic 500 20px/24px Akzidenz-Grotesk Pro;
+$font-body-super: 900 22px/26.4px Akzidenz-Grotesk Pro;
 $effect-drop-shadow-single: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 $effect-inner-shadow-multiple-0: inset 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 $effect-inner-shadow-multiple-1: inset 10px 100px 1px 0.5px rgb(0, 0, 0);

--- a/src/web/webFont.js
+++ b/src/web/webFont.js
@@ -9,6 +9,6 @@ module.exports = {
   },
   transformer: function ({ value: font }, { options }) {
     // font: font-style font-variant font-weight font-size/line-height font-family;
-    return `${notDefault(font.fontStretch, 'normal')} ${notDefault(font.fontStyle, 'normal')} ${font.fontWeight} ${font.fontSize}/${font.lineHeight} ${fontFamily(font, options)}`.trim()
+    return `${notDefault(font.fontStretch, 'normal')} ${notDefault(font.fontStyle, 'normal')} ${font.fontWeight} ${font.fontSize}px/${font.lineHeight}px ${fontFamily(font, options)}`.trim()
   }
 }


### PR DESCRIPTION
In current implementation of `custom-fontStyle` token for web `font-size` and `line-height` are unitless s so they can't be used directly in `font` CSS property.